### PR TITLE
Fixing SDL2 video backend implementation; fix Linux builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ifeq ($(STATIC),1)
 	CFLAGS += -static
 endif
 
-LDFLAGS   = $(CFLAGS)
+LDFLAGS   =
 
 DEFINES   += -DLSB_FIRST -DUSE_32BPP_RENDERING \
 			-DMAXROMSIZE=4194304 -DHAVE_NO_SPRITE_LIMIT \
@@ -238,7 +238,7 @@ $(OBJDIR)/%.o: %.cpp
 
 $(BINPATH): $(OBJDIR) $(OBJECTS)
 	@echo -n Linking...
-	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBS) -o $@
+	$(CXX) $(CFLAGS) $(OBJECTS) $(LIBS) -o $@ $(LDFLAGS)
 	@echo " Done!"
 
 ifeq ($(BINPATH),$(PKGPATH))

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ $(OBJDIR)/%.o: %.cpp
 
 $(BINPATH): $(OBJDIR) $(OBJECTS)
 	@echo -n Linking...
-	$(CXX) $(CFLAGS) $(OBJECTS) $(LIBS) -o $@ $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS)
 	@echo " Done!"
 
 ifeq ($(BINPATH),$(PKGPATH))

--- a/Makefile_cfgs/Backends/Audio/sdl2mixer.cfg
+++ b/Makefile_cfgs/Backends/Audio/sdl2mixer.cfg
@@ -1,3 +1,3 @@
-CFLAGS += `$(PKGCONFIG) --cflags SDL2_mixer opusfile libmpg123 flac vorbis`
-LIBS += `$(PKGCONFIG) --libs SDL2_mixer opusfile libmpg123 flac vorbis`
+CFLAGS += `$(PKGCONFIG) --cflags SDL2_mixer flac vorbis`
+LIBS += `$(PKGCONFIG) --libs SDL2_mixer flac vorbis`
 SOURCES +=	src/backends/sound/sound_sdl2mixer

--- a/Makefile_cfgs/Backends/Audio/sdlmixer.cfg
+++ b/Makefile_cfgs/Backends/Audio/sdlmixer.cfg
@@ -1,3 +1,3 @@
-CFLAGS += `$(PKGCONFIG) --cflags SDL_mixer opusfile libmpg123 flac mad`
-LIBS += `$(PKGCONFIG) --libs SDL_mixer opusfile libmpg123 flac mad`
+CFLAGS += `$(PKGCONFIG) --cflags SDL_mixer flac mad`
+LIBS += `$(PKGCONFIG) --libs SDL_mixer flac mad`
 SOURCES +=	src/backends/sound/sound_sdlmixer

--- a/Makefile_cfgs/Backends/Video/sdl2.cfg
+++ b/Makefile_cfgs/Backends/Video/sdl2.cfg
@@ -1,3 +1,3 @@
-CFLAGS += `$(PKGCONFIG) --cflags sdl2 sdl2_image libjpeg libpng libwebp libtiff-4`
-LIBS += `$(PKGCONFIG) --libs sdl2 sdl2_image libjpeg libpng libwebp libtiff-4`
+CFLAGS += `$(PKGCONFIG) --cflags sdl2 SDL2_image libjpeg libpng libtiff-4`
+LIBS += `$(PKGCONFIG) --libs sdl2 SDL2_image libjpeg libpng libtiff-4`
 SOURCES +=	src/backends/video/video_sdl2

--- a/Makefile_cfgs/Platforms/Switch.cfg
+++ b/Makefile_cfgs/Platforms/Switch.cfg
@@ -15,7 +15,8 @@ CFLAGS +=	-DARM -march=armv8-a -mtune=cortex-a57 -mtp=soft -DLSB_FIRST \
 			-DM68K_OVERCLOCK_SHIFT=20 -DHAVE_ZLIB -DSWITCH -fPIE \
 			-Wl,--allow-multiple-definition -specs=$(DEVKITPRO)/libnx/switch.specs
 DEFINES +=	-DHAVE_ALLOCA_H -DUSE_NORMAL_SLEEP
-LIBS +=		-L$(LIBNX)/lib -lnx -lEGL -lm -lglapi -lm -ldrm_nouveau
+LDFLAGS +=	-L$(LIBNX)/lib
+LIBS +=		-lnx -lEGL -lm -lglapi -lm -ldrm_nouveau
 INCLUDES +=	-I$(LIBNX)/include -I$(PORTLIBS)/include/GLFW -I$(PORTLIBS)/include
 
 ifdef NXLINK

--- a/src/backends/video/video_sdl2.cpp
+++ b/src/backends/video/video_sdl2.cpp
@@ -52,7 +52,13 @@ void Init_Bitmap() {
     SURFACE_FORMAT
   );
 
-  sdl_texture = SDL_CreateTextureFromSurface(sdl_renderer, sdl_bitmap);
+  sdl_texture = SDL_CreateTexture(
+    sdl_renderer, 
+    SURFACE_FORMAT, 
+    SDL_TEXTUREACCESS_STREAMING,
+    VIDEO_WIDTH,
+    (VIDEO_HEIGHT * 2) + 1
+  );
   SDL_SetTextureBlendMode(sdl_texture, SDL_BLENDMODE_BLEND);
 
   SDL_LockSurface(sdl_bitmap);
@@ -116,8 +122,6 @@ void Update_Viewport() {
   if (!(bitmap.viewport.changed & 1)) return;
 
   /* viewport size changed */
-  sdl_winsurf  = SDL_GetWindowSurface(sdl_window);
-
   #if defined(SWITCH) || defined(MACOS)
   screen_width = 1280;
   screen_height = 720;
@@ -125,8 +129,11 @@ void Update_Viewport() {
   screen_width = 960;
   screen_height = 544;
   #else
-  screen_width = sdl_winsurf->w;
-  screen_height = sdl_winsurf->h;
+  SDL_Rect window_rect = { .x = 0, .y = 0 };
+  SDL_GetWindowSize(sdl_window, &window_rect.w, &window_rect.h);
+
+  screen_width = window_rect.w;
+  screen_height = window_rect.h;
   #endif
 
   bitmap.viewport.changed &= ~1;
@@ -170,8 +177,7 @@ void Update_Viewport() {
     rect_dest.y *= 0.9343065693430657;
   #endif
 
-  /* clear destination surface */
-  SDL_FillRect(sdl_winsurf, 0, 0);
+  // TODO: Clear window contents without relying on "SDL_GetWindowSurface".
 }
 
 void Update_Texture() {


### PR DESCRIPTION
This PR fixes initialization of texture for image display (use "SDL_TEXTUREACCESS_STREAMING" flag instead of "SDL_TEXTUREACCESS_STATIC" hint) and incorrect use of "SDL_GetWindowSurface" with the hardware-accelerated renderer.

It effectively fixes emulator crashes on Linux systems (and possibly, other platforms), though some extra testing may be required to retain compatibility with Windows and changing MD video modes by the game itself.